### PR TITLE
Update Ford Transit Connect generations: Add generations.yaml with 5 generation entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 This repository contains signal set configurations for the Ford Transit Connect, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Ford Transit Connect.
 
-## Generations
-
-- **First Generation (2002-2013)**: Introduced initially in Europe as a compact panel van, the first-generation Transit Connect was built on Ford's C170 platform. It featured a front-wheel-drive layout and was powered by various engines including a 2.0L gasoline engine and several diesel options. The vehicle was notable for its high roof design and sliding side doors, making it ideal for commercial use. In 2009, it received a facelift that included updated styling and interior improvements.
-
-- **Second Generation (2013-2023)**: Built on Ford's Global C platform, the second generation brought significant modernization to the Transit Connect. It offered both short and long wheelbase variants and was available in passenger and cargo configurations. Engine options included a 2.5L inline-four and a more efficient 1.6L EcoBoost engine, later updated to include a 2.0L direct-injection four-cylinder. This generation featured improved safety features, better fuel economy, and more refined driving dynamics.
-
-- **Third Generation (2024-present)**: The latest generation Transit Connect is based on Volkswagen's Caddy platform as part of a Ford-VW commercial vehicle partnership. It features modern driver assistance systems, improved connectivity options, and more efficient powertrains including electrified options. The new generation maintains the vehicle's practical nature while offering enhanced comfort and technology features.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,28 @@
+references:
+  - "https://en.wikipedia.org/wiki/Ford_Transit_Connect"
+
+generations:
+  - name: "First Generation"
+    start_year: 2002
+    end_year: 2013
+    description: "Introduced in Europe in October 2002 as a replacement for car-derived vans (Ford Escort Van and Ford Fiesta Courier). Built on the Ford C170 platform with front-wheel-drive layout. Available in short wheelbase (SWB) and long wheelbase (LWB) variants with sliding side doors. Powered by 1.8L Duratorq TDCi diesel, 2.0L Endura-D TDDi diesel, and 2.0L Duratec gasoline engines."
+
+  - name: "First Generation (2009 Facelift)"
+    start_year: 2009
+    end_year: 2013
+    description: "Mid-cycle facelift introduced alongside North American导入. Features restyled front grille, deeper front bumper, and new dashboard with switchgear from the C307 Ford Focus. The North American variant was introduced for 2010 model year with 2.0L Duratec gasoline engine and 4-speed automatic transmission."
+
+  - name: "Second Generation"
+    start_year: 2012
+    end_year: 2018
+    description: "Introduced on September 6, 2012 in Amsterdam. Built on Ford's Global C-car platform with Kinetic Design language. Produced at Valencia, Spain. Available in SWB and LWB with panel van and leisure activity vehicle (LAV) body styles. Engine options include 1.0L EcoBoost I3, 1.6L EcoBoost I4, 2.5L Duratec I4, and 1.5L Duratorq diesel."
+
+  - name: "Second Generation (2019 Facelift)"
+    start_year: 2019
+    end_year: 2023
+    description: "Mid-life update for the 2019 model year with updated front fascia and redesigned dashboard. The 2.5L engine was replaced by a 2.0L direct-injection I4 (while remaining optional for LPG/CNG). New 1.5L EcoBlue diesel engine introduced, paired with an 8-speed automatic transmission. Production ended in North America after 2023 model year."
+
+  - name: "Third Generation"
+    start_year: 2021
+    end_year: null
+    description: "Rebadged fourth-generation Volkswagen Caddy as part of Ford-VW commercial vehicle partnership. Built on Volkswagen Group MQB platform at VW Poznań, Poland. Engine options include 1.5L TSI petrol, 1.5L TSI plug-in hybrid (150hp combined), and 2.0L TDI diesel. Transit Connect badging released in late 2024."


### PR DESCRIPTION
- Created generations.yaml with references to Wikipedia article
- First Generation (2002-2013): Original C170 platform variant
- First Generation 2009 Facelift (2009-2013): North American import update with new dashboard
- Second Generation (2012-2018): Global C platform with Kinetic Design
- Second Generation 2019 Facelift (2019-2023): Updated fascia, new engines
- Third Generation (2021-present): VW Caddy-based MQB platform variant
- Removed Generations section from README.md (data now in generations.yaml)
